### PR TITLE
Add server-side email handling for contact form

### DIFF
--- a/Desktop/Coding/Projects/WaseWaterWerken/index.html
+++ b/Desktop/Coding/Projects/WaseWaterWerken/index.html
@@ -311,18 +311,18 @@
             <div class="max-w-3xl mx-auto bg-white rounded-2xl shadow-lg p-8 border border-primary-100">
               <h2 class="text-3xl font-bold mb-4">Contact</h2>
               <p class="text-gray-600 mb-6">Vraag een offerte of stel uw vraag. We reageren zo snel mogelijk.</p>
-              <form class="grid grid-cols-1 md:grid-cols-2 gap-6" onsubmit="event.preventDefault(); alert('Bedankt! We nemen snel contact op.');">
+              <form class="grid grid-cols-1 md:grid-cols-2 gap-6" action="sendmail.php" method="POST">
                 <div class="md:col-span-1">
                   <label class="block text-sm font-medium mb-1" for="naam">Naam</label>
-                  <input id="naam" type="text" class="w-full border border-neutral-300 rounded-lg px-4 py-3 focus:outline-none focus:ring-2 focus:ring-primary-400" placeholder="Uw naam" required>
+                  <input id="naam" name="naam" type="text" class="w-full border border-neutral-300 rounded-lg px-4 py-3 focus:outline-none focus:ring-2 focus:ring-primary-400" placeholder="Uw naam" required>
                 </div>
                 <div class="md:col-span-1">
                   <label class="block text-sm font-medium mb-1" for="email">E‑mail</label>
-                  <input id="email" type="email" class="w-full border border-neutral-300 rounded-lg px-4 py-3 focus:outline-none focus:ring-2 focus:ring-primary-400" placeholder="naam@voorbeeld.be" required>
+                  <input id="email" name="email" type="email" class="w-full border border-neutral-300 rounded-lg px-4 py-3 focus:outline-none focus:ring-2 focus:ring-primary-400" placeholder="naam@voorbeeld.be" required>
                 </div>
                 <div class="md:col-span-2">
                   <label class="block text-sm font-medium mb-1" for="bericht">Bericht</label>
-                  <textarea id="bericht" rows="4" class="w-full border border-neutral-300 rounded-lg px-4 py-3 focus:outline-none focus:ring-2 focus:ring-primary-400" placeholder="Beschrijf kort uw vraag of project" required></textarea>
+                  <textarea id="bericht" name="bericht" rows="4" class="w-full border border-neutral-300 rounded-lg px-4 py-3 focus:outline-none focus:ring-2 focus:ring-primary-400" placeholder="Beschrijf kort uw vraag of project" required></textarea>
                 </div>
                 <div class="md:col-span-2 flex justify-between items-center">
                   <small class="text-gray-500">Geen spam. We gebruiken uw gegevens enkel om te antwoorden.</small>

--- a/Desktop/Coding/Projects/WaseWaterWerken/sendmail.php
+++ b/Desktop/Coding/Projects/WaseWaterWerken/sendmail.php
@@ -1,0 +1,25 @@
+<?php
+if ($_SERVER["REQUEST_METHOD"] === "POST") {
+    $name = isset($_POST['naam']) ? htmlspecialchars(trim($_POST['naam'])) : '';
+    $email = isset($_POST['email']) ? filter_var(trim($_POST['email']), FILTER_SANITIZE_EMAIL) : '';
+    $message = isset($_POST['bericht']) ? htmlspecialchars(trim($_POST['bericht'])) : '';
+
+    $to = 'info@wasewaterwerken.be';
+    $subject = 'Nieuw bericht van contactformulier';
+    $headers = "From: $email\r\n";
+    $headers .= "Reply-To: $email\r\n";
+    $headers .= "Content-Type: text/plain; charset=utf-8\r\n";
+
+    $body = "Naam: $name\nE-mail: $email\n\nBericht:\n$message\n";
+
+    if (mail($to, $subject, $body, $headers)) {
+        echo 'Bedankt! We nemen snel contact op.';
+    } else {
+        http_response_code(500);
+        echo 'Er is een fout opgetreden. Probeer opnieuw.';
+    }
+} else {
+    http_response_code(405);
+    echo 'Method not allowed';
+}
+?>


### PR DESCRIPTION
## Summary
- wire up contact form to send data via POST
- add PHP handler to email submissions to info@wasewaterwerken.be

## Testing
- `php -l Desktop/Coding/Projects/WaseWaterWerken/sendmail.php`


------
https://chatgpt.com/codex/tasks/task_e_689dfdcfd740832b87b955d3aeba95db