### PR TITLE
Add basic 403 and 404 error pages

### DIFF
--- a/Desktop/Coding/Projects/WaseWaterWerken/403.html
+++ b/Desktop/Coding/Projects/WaseWaterWerken/403.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Geen toegang - WaseWaterwerken</title>
+    <style>
+      @import url(https://fonts.googleapis.com/css2?family=Lato&display=swap);
+      @import url(https://fonts.googleapis.com/css2?family=Open+Sans&display=swap);
+      @import url(https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined);
+      @import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css);
+    </style>
+  </head>
+  <body class="bg-primary-50 flex items-center justify-center min-h-screen text-center">
+    <div>
+      <h1 class="text-6xl font-bold text-primary-700 mb-4">403</h1>
+      <p class="text-xl text-gray-700 mb-8">Geen toegang</p>
+      <a href="index.html" class="text-primary-600 underline">Ga naar home</a>
+    </div>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+      tailwind.config = {
+        theme: {
+          extend: {
+            colors: {
+              primary: {
+                50: '#f3f1ff',
+                100: '#e9e5ff',
+                200: '#d5cfff',
+                300: '#b7a9ff',
+                400: '#9478ff',
+                500: '#7341ff',
+                600: '#631bff',
+                700: '#611bf8',
+                800: '#4607d0',
+                900: '#3c08aa',
+                950: '#220174'
+              },
+              neutral: {
+                50: '#f7f7f7',
+                100: '#eeeeee',
+                200: '#e0e0e0',
+                300: '#cacaca',
+                400: '#b1b1b1',
+                500: '#999999',
+                600: '#7f7f7f',
+                700: '#676767',
+                800: '#545454',
+                900: '#464646',
+                950: '#282828'
+              }
+            }
+          },
+          fontFamily: {
+            sans: ['Open Sans', 'ui-sans-serif', 'system-ui', 'sans-serif', '"Apple Color Emoji"', '"Segoe UI Emoji"', '"Segoe UI Symbol"', '"Noto Color Emoji"'],
+            title: ['Lato', 'ui-sans-serif', 'system-ui', 'sans-serif', '"Apple Color Emoji"', '"Segoe UI Emoji"', '"Segoe UI Symbol"', '"Noto Color Emoji"'],
+            body: ['Open Sans', 'ui-sans-serif', 'system-ui', 'sans-serif', '"Apple Color Emoji"', '"Segoe UI Emoji"', '"Segoe UI Symbol"', '"Noto Color Emoji"']
+          }
+        },
+        important: '#webcrumbs'
+      };
+    </script>
+  </body>
+</html>

--- a/Desktop/Coding/Projects/WaseWaterWerken/404.html
+++ b/Desktop/Coding/Projects/WaseWaterWerken/404.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Pagina niet gevonden - WaseWaterwerken</title>
+    <style>
+      @import url(https://fonts.googleapis.com/css2?family=Lato&display=swap);
+      @import url(https://fonts.googleapis.com/css2?family=Open+Sans&display=swap);
+      @import url(https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined);
+      @import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css);
+    </style>
+  </head>
+  <body class="bg-primary-50 flex items-center justify-center min-h-screen text-center">
+    <div>
+      <h1 class="text-6xl font-bold text-primary-700 mb-4">404</h1>
+      <p class="text-xl text-gray-700 mb-8">Pagina niet gevonden</p>
+      <a href="index.html" class="text-primary-600 underline">Ga naar home</a>
+    </div>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+      tailwind.config = {
+        theme: {
+          extend: {
+            colors: {
+              primary: {
+                50: '#f3f1ff',
+                100: '#e9e5ff',
+                200: '#d5cfff',
+                300: '#b7a9ff',
+                400: '#9478ff',
+                500: '#7341ff',
+                600: '#631bff',
+                700: '#611bf8',
+                800: '#4607d0',
+                900: '#3c08aa',
+                950: '#220174'
+              },
+              neutral: {
+                50: '#f7f7f7',
+                100: '#eeeeee',
+                200: '#e0e0e0',
+                300: '#cacaca',
+                400: '#b1b1b1',
+                500: '#999999',
+                600: '#7f7f7f',
+                700: '#676767',
+                800: '#545454',
+                900: '#464646',
+                950: '#282828'
+              }
+            }
+          },
+          fontFamily: {
+            sans: ['Open Sans', 'ui-sans-serif', 'system-ui', 'sans-serif', '"Apple Color Emoji"', '"Segoe UI Emoji"', '"Segoe UI Symbol"', '"Noto Color Emoji"'],
+            title: ['Lato', 'ui-sans-serif', 'system-ui', 'sans-serif', '"Apple Color Emoji"', '"Segoe UI Emoji"', '"Segoe UI Symbol"', '"Noto Color Emoji"'],
+            body: ['Open Sans', 'ui-sans-serif', 'system-ui', 'sans-serif', '"Apple Color Emoji"', '"Segoe UI Emoji"', '"Segoe UI Symbol"', '"Noto Color Emoji"']
+          }
+        },
+        important: '#webcrumbs'
+      };
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add stylized 404 error page for missing resources
- add matching 403 page for restricted access

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e00595cd0832bb01924dc4bf52e62